### PR TITLE
Fixes double-subscribe bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core-ephemeral",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Discipl Core Ephemeral Connector",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/EphemeralClient.js
+++ b/src/EphemeralClient.js
@@ -73,17 +73,19 @@ class EphemeralClient {
             const MAX_TRIES = 10
             for (let i = 0; i < MAX_TRIES; i++) {
               await timeoutPromise(50)
-
-              await axios.post(this.serverEndpoint + '/observe', {
-                'nonce': nonce,
-                'scope': publicKey,
-                'accessorPubkey': accessorPubkey,
-                'accessorSignature': accessorSignature
-              }).then((r) => {
-                resolve()
-              }).catch((e) => {
-                // Purposeful no-op
-              })
+              try {
+                await axios.post(this.serverEndpoint + '/observe', {
+                  'nonce': nonce,
+                  'scope': publicKey,
+                  'accessorPubkey': accessorPubkey,
+                  'accessorSignature': accessorSignature
+                }).then((r) => {
+                  resolve()
+                })
+                return
+              } catch (e) {
+                // Purpose-ful no-op
+              }
             }
 
             reject(new Error('Timed out'))


### PR DESCRIPTION
This used to do multiple calls, even on success. This way it will
actually return from the subscriber if a successful call comes back.

I would have introduced a test, but since it would rely on the internal workings of promise and how quickly it's resolved I have no idea how to do it.