### PR TITLE
Add link to the object exposed by observe

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core-ephemeral",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Discipl Core Ephemeral Connector",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/EphemeralConnector.js
+++ b/src/EphemeralConnector.js
@@ -207,9 +207,11 @@ class EphemeralConnector extends BaseConnector {
         claim['claim'].previous = this.linkFromReference(claim['claim'].previous)
       }
 
+      claim['link'] = this.linkFromReference(claim['claim'].signature)
       delete claim['claim'].signature
       claim['did'] = this.didFromReference(claim['pubkey'])
       delete claim['pubkey']
+
       return claim
     })).pipe(filter(claim => {
       if (claimFilter != null) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -375,7 +375,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': accessClaimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink
           })
         })
 
@@ -405,7 +406,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': accessClaimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink
           },
           {
             'claim': {
@@ -414,7 +416,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': claimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink2
           }
           ])
         })
@@ -444,7 +447,8 @@ describe('discipl-ephemeral-connector', () => {
                 },
                 'previous': allowClaimLink
               },
-              'did': identity.did
+              'did': identity.did,
+              'link': claimLink2
             }
           )
         })
@@ -479,7 +483,8 @@ describe('discipl-ephemeral-connector', () => {
                 },
                 'previous': allowClaimLink
               },
-              'did': identity.did
+              'did': identity.did,
+              'link': claimLink2
             }
           )
         })
@@ -586,7 +591,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': accessClaimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink
           })
         })
 
@@ -611,7 +617,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': null
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink
           })
         })
 
@@ -627,7 +634,7 @@ describe('discipl-ephemeral-connector', () => {
           await ephemeralConnector.claim(identity.did, identity.privkey, { [BaseConnector.ALLOW]: {} })
 
           let claimLink = await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'beer' })
-          await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
+          let claimLink2 = await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
           await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'tea' })
           let observed = await observer
 
@@ -638,7 +645,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': claimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink2
           })
         })
 
@@ -654,7 +662,7 @@ describe('discipl-ephemeral-connector', () => {
           await ephemeralConnector.claim(identity.did, identity.privkey, { [BaseConnector.ALLOW]: {} })
 
           let claimLink = await ephemeralConnector.claim(identity.did, identity.privkey, { 'desire': 'beer' })
-          await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
+          let claimLink2 = await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
           await ephemeralConnector.claim(identity.did, identity.privkey, { 'desire': 'tea' })
           let observed = await observer
 
@@ -665,7 +673,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': claimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink2
           })
         })
 
@@ -681,7 +690,7 @@ describe('discipl-ephemeral-connector', () => {
           await ephemeralConnector.claim(identity.did, identity.privkey, { [BaseConnector.ALLOW]: {} })
 
           let claimLink = await ephemeralConnector.claim(identity.did, identity.privkey, { 'desire': 'beer' })
-          await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
+          let claimLink2 = await ephemeralConnector.claim(identity.did, identity.privkey, { 'need': 'wine' })
           await ephemeralConnector.claim(identity.did, identity.privkey, { 'desire': 'tea' })
           let observed = await observer
 
@@ -692,7 +701,8 @@ describe('discipl-ephemeral-connector', () => {
               },
               'previous': claimLink
             },
-            'did': identity.did
+            'did': identity.did,
+            'link': claimLink2
           })
         })
       })


### PR DESCRIPTION
I've observed various situations where this would be useful, and in fact, this should have been here from the beginning. 

This change doesn't break the API, but might require downstream libraries to adapt tests, if they depend on the exact structure of the observe contents.