### PR TITLE
Only generate keys if they are actually needed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@discipl/core-ephemeral",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Discipl Core Ephemeral Connector",
   "main": "dist/index.js",
   "module": "src/index.js",

--- a/src/EphemeralConnector.js
+++ b/src/EphemeralConnector.js
@@ -73,7 +73,7 @@ class EphemeralConnector extends BaseConnector {
    * @returns {Promise<EphemeralSsid>} ssid-object, containing both the did and the authentication mechanism.
    */
   async newIdentity (options = {}) {
-    let keypair = forge.pki.rsa.generateKeyPair(2048)
+    let keypair = options.cert ? null : forge.pki.rsa.generateKeyPair(2048)
     let cert = options.cert ? forge.pki.certificateFromPem(options.cert) : EphemeralConnector._createCert(keypair)
 
     let fingerprint = forge.pki.getPublicKeyFingerprint(cert.publicKey, {
@@ -82,9 +82,11 @@ class EphemeralConnector extends BaseConnector {
 
     await this.ephemeralClient.storeCert(fingerprint, cert)
 
+    let privkey = options.cert ? (options.privkey ? options.privkey : null) : forge.pki.privateKeyToPem(keypair.privateKey)
+
     return {
       'did': this.didFromReference(fingerprint),
-      'privkey': options.privkey || forge.pki.privateKeyToPem(keypair.privateKey),
+      'privkey': privkey,
       'metadata': {
         'cert': forge.pki.certificateToPem(cert)
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -33,6 +33,157 @@ describe('discipl-ephemeral-connector', () => {
       expect(identity.privkey.length).to.be.above(1700)
     })
 
+    it('should be able to import an identity with a public key', async () => {
+      let cert = '-----BEGIN CERTIFICATE-----\r\n' +
+        'MIIGGzCCBAOgAwIBAgIUDqjzvfWzZ7dyHuIBerf5m/N09qMwDQYJKoZIhvcNAQEL\r\n' +
+        'BQAwgZwxCzAJBgNVBAYTAk5MMRUwEwYDVQQIDAxadWlkLUhvbGxhbmQxETAPBgNV\r\n' +
+        'BAcMCERlbiBIYWFnMQ0wCwYDVQQKDARJQ1RVMRAwDgYDVQQLDAdEaXNjaXBsMR4w\r\n' +
+        'HAYDVQQDDBV0ZXN0LWNlcnQuZXhhbXBsZS5jb20xIjAgBgkqhkiG9w0BCQEWE25v\r\n' +
+        'cmVwbHlAZXhhbXBsZS5jb20wHhcNMTkwNTA5MDcyODUxWhcNMjAwNTA4MDcyODUx\r\n' +
+        'WjCBnDELMAkGA1UEBhMCTkwxFTATBgNVBAgMDFp1aWQtSG9sbGFuZDERMA8GA1UE\r\n' +
+        'BwwIRGVuIEhhYWcxDTALBgNVBAoMBElDVFUxEDAOBgNVBAsMB0Rpc2NpcGwxHjAc\r\n' +
+        'BgNVBAMMFXRlc3QtY2VydC5leGFtcGxlLmNvbTEiMCAGCSqGSIb3DQEJARYTbm9y\r\n' +
+        'ZXBseUBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB\r\n' +
+        'AL28MtQ1j6n53jpVnwhLgiVegCXdnTuXztd44AsZbO7EhK14mdKkTUH542LfiGWK\r\n' +
+        'XwVSOwkmroTQnbD3AzCpG7l3xUx4x5bsiBAgoznsYbKrr4PFeoLmjgb0DA49mNOJ\r\n' +
+        'cC16G7SBhJS5WrUh9Twgp4lG07e9pFVvVXKQtcGW3vnt9naoZuIiN3pCIG0ObfRv\r\n' +
+        'A/uvn+lQ2r6k0YcWo/BWmJf/7bdhFHH6+oEMasQT/i+mGtRIBgOwu77k/1qDmtco\r\n' +
+        'glpu51UKoRdAkruyVO2OFPXJrMVvttnKdoS0GT3ZkxWzH+YPAWrtf+OZTJXT3bGS\r\n' +
+        'rhKZrWlmoRo3EFiHjw1vF48E/jiueC9+P+j/fgiV7A613cAmEwL0ggmutOlaKkXq\r\n' +
+        'dniaSRSN526KmTvsgSRA/c900dfb1dIvEigYGBQM5GLCZq6ShwPQ3L0OUnEobT1v\r\n' +
+        'bKmO+G80fJu2x+q8q1z+XTEOTmfNQDe7MHd3XftrwgONmulYsA94Wa1Fb7shRQgr\r\n' +
+        '3u4MmZH1VXFw+mbEU39AxEd3cv5AA05go2OK0vb463XPjCro/h1/SyKDjDGaEkGG\r\n' +
+        '1PlBlVrTic48m0R/yek6Y/jm81+I0oasrKt5e+bHHVo8esDf0idohYjtHFgRtZ5S\r\n' +
+        'VuSU4LaaYdnSabrEYTobFNXhYQUgBFxAQyRIPLZadsrRAgMBAAGjUzBRMB0GA1Ud\r\n' +
+        'DgQWBBSq3yobDJHW0k7fyKPXiFcjYt1rpDAfBgNVHSMEGDAWgBSq3yobDJHW0k7f\r\n' +
+        'yKPXiFcjYt1rpDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQC2\r\n' +
+        'bXsl/bt2OvLDOP86UXGHEOoSAVggAOmQZJXiNZ/rH71mfhMz0qrrY5zmMITGk6la\r\n' +
+        '1GPkrkWUiLi7fhcBTp4Kzr/+kifZ9uaN3EPg6bsqcf4Qs/OTb1HutI31jh0eOfxe\r\n' +
+        'VW6aC5B57MdQLdj7gll0r9+GKVlgQq7UgbBmWum54MNGAIsQc0FR6Wv5wBY/AO4q\r\n' +
+        'eiMNcpzocGv9RhkVft/hhZqc8A0gmIokDjO+gdUNjaxRTNp57uwK89QZ9NnOso8P\r\n' +
+        'kiCU8/R1Lzj4QL7OPq4wGLbQskEpyQgfRiUPyAyLIsds7bx1n8KX9ycG4NY3G9tQ\r\n' +
+        'HE+iuxu9WvEelCDSvgLEUU/KpFS3koDrrq5NQB56O5wKad1J8wK1RqKFzNR9DSYH\r\n' +
+        '/KGyjIbWlv4ESi9HoJcWKIVoAbtQzmC23bod5ZcuhrSebnVLwsJDhN5MAb21byF2\r\n' +
+        'RYEKjatMThWkW7ubwweIlHprX4SsKqEbZD/d17u8Yz52hGwYKWaMo1FiRLMyqzh7\r\n' +
+        'xNpWcpBgtAFZbzhQoxN/IQE2t0Zo1P1f+7stRFFeul3WV6UKDbU6Lby9ZsMAUein\r\n' +
+        'KGmm+a0d9n9Xm9/u4O1OGLNio57d0RKPWQn+3pZWga+aP202u5QSVeblRiXliUU3\r\n' +
+        'OxemhmosTIoo9vBwsjK8aOsi7TVgeceqSMszxeUX+g==\r\n' +
+        '-----END CERTIFICATE-----\r\n'
+
+      let ephemeralConnector = new EphemeralConnector()
+      let identity = await ephemeralConnector.newIdentity({ 'cert': cert })
+
+      expect(identity).to.deep.equal({
+        'did': 'did:discipl:ephemeral:aadf2a1b0c91d6d24edfc8a3d788572362dd6ba4',
+        'metadata': {
+          'cert': cert
+        },
+        'privkey': null
+      })
+    })
+
+    it('should be able to import an identity with a public and private key', async () => {
+      let cert = '-----BEGIN CERTIFICATE-----\r\n' +
+        'MIIGGzCCBAOgAwIBAgIUDqjzvfWzZ7dyHuIBerf5m/N09qMwDQYJKoZIhvcNAQEL\r\n' +
+        'BQAwgZwxCzAJBgNVBAYTAk5MMRUwEwYDVQQIDAxadWlkLUhvbGxhbmQxETAPBgNV\r\n' +
+        'BAcMCERlbiBIYWFnMQ0wCwYDVQQKDARJQ1RVMRAwDgYDVQQLDAdEaXNjaXBsMR4w\r\n' +
+        'HAYDVQQDDBV0ZXN0LWNlcnQuZXhhbXBsZS5jb20xIjAgBgkqhkiG9w0BCQEWE25v\r\n' +
+        'cmVwbHlAZXhhbXBsZS5jb20wHhcNMTkwNTA5MDcyODUxWhcNMjAwNTA4MDcyODUx\r\n' +
+        'WjCBnDELMAkGA1UEBhMCTkwxFTATBgNVBAgMDFp1aWQtSG9sbGFuZDERMA8GA1UE\r\n' +
+        'BwwIRGVuIEhhYWcxDTALBgNVBAoMBElDVFUxEDAOBgNVBAsMB0Rpc2NpcGwxHjAc\r\n' +
+        'BgNVBAMMFXRlc3QtY2VydC5leGFtcGxlLmNvbTEiMCAGCSqGSIb3DQEJARYTbm9y\r\n' +
+        'ZXBseUBleGFtcGxlLmNvbTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIB\r\n' +
+        'AL28MtQ1j6n53jpVnwhLgiVegCXdnTuXztd44AsZbO7EhK14mdKkTUH542LfiGWK\r\n' +
+        'XwVSOwkmroTQnbD3AzCpG7l3xUx4x5bsiBAgoznsYbKrr4PFeoLmjgb0DA49mNOJ\r\n' +
+        'cC16G7SBhJS5WrUh9Twgp4lG07e9pFVvVXKQtcGW3vnt9naoZuIiN3pCIG0ObfRv\r\n' +
+        'A/uvn+lQ2r6k0YcWo/BWmJf/7bdhFHH6+oEMasQT/i+mGtRIBgOwu77k/1qDmtco\r\n' +
+        'glpu51UKoRdAkruyVO2OFPXJrMVvttnKdoS0GT3ZkxWzH+YPAWrtf+OZTJXT3bGS\r\n' +
+        'rhKZrWlmoRo3EFiHjw1vF48E/jiueC9+P+j/fgiV7A613cAmEwL0ggmutOlaKkXq\r\n' +
+        'dniaSRSN526KmTvsgSRA/c900dfb1dIvEigYGBQM5GLCZq6ShwPQ3L0OUnEobT1v\r\n' +
+        'bKmO+G80fJu2x+q8q1z+XTEOTmfNQDe7MHd3XftrwgONmulYsA94Wa1Fb7shRQgr\r\n' +
+        '3u4MmZH1VXFw+mbEU39AxEd3cv5AA05go2OK0vb463XPjCro/h1/SyKDjDGaEkGG\r\n' +
+        '1PlBlVrTic48m0R/yek6Y/jm81+I0oasrKt5e+bHHVo8esDf0idohYjtHFgRtZ5S\r\n' +
+        'VuSU4LaaYdnSabrEYTobFNXhYQUgBFxAQyRIPLZadsrRAgMBAAGjUzBRMB0GA1Ud\r\n' +
+        'DgQWBBSq3yobDJHW0k7fyKPXiFcjYt1rpDAfBgNVHSMEGDAWgBSq3yobDJHW0k7f\r\n' +
+        'yKPXiFcjYt1rpDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4ICAQC2\r\n' +
+        'bXsl/bt2OvLDOP86UXGHEOoSAVggAOmQZJXiNZ/rH71mfhMz0qrrY5zmMITGk6la\r\n' +
+        '1GPkrkWUiLi7fhcBTp4Kzr/+kifZ9uaN3EPg6bsqcf4Qs/OTb1HutI31jh0eOfxe\r\n' +
+        'VW6aC5B57MdQLdj7gll0r9+GKVlgQq7UgbBmWum54MNGAIsQc0FR6Wv5wBY/AO4q\r\n' +
+        'eiMNcpzocGv9RhkVft/hhZqc8A0gmIokDjO+gdUNjaxRTNp57uwK89QZ9NnOso8P\r\n' +
+        'kiCU8/R1Lzj4QL7OPq4wGLbQskEpyQgfRiUPyAyLIsds7bx1n8KX9ycG4NY3G9tQ\r\n' +
+        'HE+iuxu9WvEelCDSvgLEUU/KpFS3koDrrq5NQB56O5wKad1J8wK1RqKFzNR9DSYH\r\n' +
+        '/KGyjIbWlv4ESi9HoJcWKIVoAbtQzmC23bod5ZcuhrSebnVLwsJDhN5MAb21byF2\r\n' +
+        'RYEKjatMThWkW7ubwweIlHprX4SsKqEbZD/d17u8Yz52hGwYKWaMo1FiRLMyqzh7\r\n' +
+        'xNpWcpBgtAFZbzhQoxN/IQE2t0Zo1P1f+7stRFFeul3WV6UKDbU6Lby9ZsMAUein\r\n' +
+        'KGmm+a0d9n9Xm9/u4O1OGLNio57d0RKPWQn+3pZWga+aP202u5QSVeblRiXliUU3\r\n' +
+        'OxemhmosTIoo9vBwsjK8aOsi7TVgeceqSMszxeUX+g==\r\n' +
+        '-----END CERTIFICATE-----\r\n'
+
+      let key = '-----BEGIN PRIVATE KEY-----\r\n' +
+        'MIIJQgIBADANBgkqhkiG9w0BAQEFAASCCSwwggkoAgEAAoICAQC9vDLUNY+p+d46\r\n' +
+        'VZ8IS4IlXoAl3Z07l87XeOALGWzuxISteJnSpE1B+eNi34hlil8FUjsJJq6E0J2w\r\n' +
+        '9wMwqRu5d8VMeMeW7IgQIKM57GGyq6+DxXqC5o4G9AwOPZjTiXAtehu0gYSUuVq1\r\n' +
+        'IfU8IKeJRtO3vaRVb1VykLXBlt757fZ2qGbiIjd6QiBtDm30bwP7r5/pUNq+pNGH\r\n' +
+        'FqPwVpiX/+23YRRx+vqBDGrEE/4vphrUSAYDsLu+5P9ag5rXKIJabudVCqEXQJK7\r\n' +
+        'slTtjhT1yazFb7bZynaEtBk92ZMVsx/mDwFq7X/jmUyV092xkq4Sma1pZqEaNxBY\r\n' +
+        'h48NbxePBP44rngvfj/o/34IlewOtd3AJhMC9IIJrrTpWipF6nZ4mkkUjeduipk7\r\n' +
+        '7IEkQP3PdNHX29XSLxIoGBgUDORiwmaukocD0Ny9DlJxKG09b2ypjvhvNHybtsfq\r\n' +
+        'vKtc/l0xDk5nzUA3uzB3d137a8IDjZrpWLAPeFmtRW+7IUUIK97uDJmR9VVxcPpm\r\n' +
+        'xFN/QMRHd3L+QANOYKNjitL2+Ot1z4wq6P4df0sig4wxmhJBhtT5QZVa04nOPJtE\r\n' +
+        'f8npOmP45vNfiNKGrKyreXvmxx1aPHrA39InaIWI7RxYEbWeUlbklOC2mmHZ0mm6\r\n' +
+        'xGE6GxTV4WEFIARcQEMkSDy2WnbK0QIDAQABAoICABDYs/6pns7t07CER7GZ2r1s\r\n' +
+        'rZ4vFjXjXcc+AU6a/FQa+NjaO3Y7hmyUPn9Z76dsaNF1Iq7GU3qRd17uH8djTIXk\r\n' +
+        'P41xr+8To2UjMLsE5QvTOKtPjngu9m9hnexpxbcKnf47uFgHo/j8mDQ7BqZHE/kZ\r\n' +
+        'Y9UNrpizYPfiJ3E/7x5r5ZVVkIUFmr1tP6nPPS4V6Vmgl2dE+Zcx1TTUasv9NGFS\r\n' +
+        'pQ3CPel86l8o9hXg3JHogrtUhcwwFgt2E8I6qzXtb92NuVaQsgr5fc3SoL3S/sNw\r\n' +
+        'G7oQGEEwO+O+hfs65Vdo5y0rKeoPmmpgAy/OdwG8T15xbLdOGIHWX8oshyQfOA0g\r\n' +
+        'lRZhoWmyRSfhe8fl0AMenMKDD9NHX+GBCEcFsgNd4qqahEd0BVFIR5K97m+9bV+V\r\n' +
+        'XNpZcwfqXEuhkbO2pAI5Xs3CXk+EXGI0WD4KaxViPP3EZJvrr74EtWiq6o6+7qVg\r\n' +
+        'dFIblJjG4dLIftdAI60EXMwVItwfk5zKdJVLvm8o0bXvoATbsKLaG2Ddl7jtmO4l\r\n' +
+        'ATCef+2MY9uaRaZQ2y2hBKRSvv2rYBXJ/2YqIj4thHZs8Z+oGvgg130y90NczRc6\r\n' +
+        '8LbauOIgWgUQ7P+Mx5uloltT379Q4PRtW0eMP6yIT9zhTcoGZjeAvrIsGmQH0Jft\r\n' +
+        'ijfLT2eufyKny61LdjfBAoIBAQDvDDx87eoUofUwO+hhwOWl1fXSuYEkJHzjpp6U\r\n' +
+        'H6XL7iFSsj3dqIhWEOX9GIsa8DDS5eFUSsqLTt95kkLJLwxm2sJjBSxiPLWxDqnO\r\n' +
+        '4l2uoZQpcP/s7xy85DtrpTvpyb/eJJBDHeFI1V7yEzTa0NI/n1xbuZhgRcVqmMG9\r\n' +
+        'M1CREyaaOUTeDqHahDz3kB/p40lNS7qQNBbOSs5S0L1raqrPHP0iNpkbkmHdR9Uq\r\n' +
+        '5LVrc57aUcN2+2vnc5wyM7wPZNK/ThwrM8SzLGg8JzD/LosFJ0WE4eg2+uUYQDvE\r\n' +
+        'LVwnbgt5olnYs47XBPJQLMVNiJPNgt6As+G/suWhZJu6vbvZAoIBAQDLMLjOsfBu\r\n' +
+        'MuimqrnvoVStUEljN3DeFaAcO+lI1WPlbVnpRYoVAGopDnjM0lRvsaDMwKRKrtMj\r\n' +
+        'Sqcq+vXlcRvfhtuMYAPsoLUyIZQcpkp3yoLsnhPkL36EL+jYmlv3b09DtcL0b6m/\r\n' +
+        '+oAGKqCZsz4PpsyP55V5fd7giuA2SJTtKHwdVo6njfgSxyg3pGv+2n47x7n0rf/n\r\n' +
+        'zuHwMx68/qNPhfPdEgY+P/A0Ab9PFqgkPSYTrHIy3dOgAVZHUbUmZsDKsGcRyU5v\r\n' +
+        'v/3GlrlPbUXbVborEeTNfNs//2XWV9/5WupjfvmKz1YoeoUFLwoFWTySkERiBbB8\r\n' +
+        'p/NhoJRvyoO5AoIBAHsfR0xlUep8nIfSY1dt/hpTQIDfsOdHr9elKwpJ3qBRr3Ij\r\n' +
+        'gf/X3RjPLVYVvRgL3GnToyJCP15PKoU4UxPCGtYjGHnd4UVb1Y0zazy2lN/sMx7B\r\n' +
+        'J+AGLDwSJZTFDz3T/vHQzUj0a+OSmot+XvvREGlakDxiNFxps0u7EBZ+BqIiRgCr\r\n' +
+        'PJBO4whkke5EmltiCJA6UAYT/icUmn5HKzjXQNDaMnrbujJcS/GoHOAx2ktUyt3R\r\n' +
+        'vSZcSvB0OGAXC2a2XGHSPmn2CPrsBWfuG6tjcpEd8A2IOY2P3k2GUAI0BsH8SQbG\r\n' +
+        'GxalLQ4May3mUV0k2lPAcw/BFqYg42skIZ2mOckCggEAIDdWZfdSjrZlqt9Q4cyr\r\n' +
+        'l1sud5u3uo6lNzTMlS64Sw0ef1z2OsQ5EM9pmdgTaS45t50nr2uusF7KyIbH7BwV\r\n' +
+        '9kf0kXo7xQ3qDMvEJxK6pemm/otFzh01qxHJkmZPBJlScQLlqUn3GShHmjKyCgyg\r\n' +
+        'X2zr7DkkuwGZD/MU/6ZcbonHvAMYVTquRZPsLX5VXTAZabMOKdxYwdFMg4AndIHP\r\n' +
+        'NPGhK8EK2l3a4PQR+CE4gZ5sZhwmcyg2wJzVqDMtTKxoDvsPLIPFevRu8Ui+kvhZ\r\n' +
+        'ZiBehyusImSUgr4k0GpYabnfhe0A9eBP4dUjOCIwLY7rirVzEjOiuvEKJsWGI39x\r\n' +
+        'iQKCAQEA2+vQTbTzpnyjTXtv4R9xHreaHxq9WLc1sd3vOa8vavejnmEZPVPP4VPn\r\n' +
+        'Pl1Ms1LHI09ppNMnYAMt5HsMC3wehhTq1BecA7lGyOJCUve9U9iTXN5MbanjkFdQ\r\n' +
+        'DGRvGDYyQuaQJXZzoC+OGV2WSZ5qMavylRlsgNY43DLkMyDeOXRoTX6AnaerHu4d\r\n' +
+        'T/HTIKN3WIX7r85bACLuHpBFJAJ5wN6Me+suyocWbRDMxem7HyyuXfYHQRyJwxSP\r\n' +
+        'W8+UZvp2V65zvkXFRI78BlEhAW1sqB+Uz0LMYvSjVkFwuPBojfPj2UFBgFMXJzFT\r\n' +
+        'gnrcsERJiRcbv67DYoSeBsigf8zA2Q==\r\n' +
+        '-----END PRIVATE KEY-----\r\n'
+
+      let ephemeralConnector = new EphemeralConnector()
+      let identity = await ephemeralConnector.newIdentity({ 'cert': cert, 'privkey': key })
+
+      expect(identity).to.deep.equal({
+        'did': 'did:discipl:ephemeral:aadf2a1b0c91d6d24edfc8a3d788572362dd6ba4',
+        'metadata': {
+          'cert': cert
+        },
+        'privkey': key
+      })
+    })
+
     it('should be able to detect wrong signatures when getting a claim', async () => {
       let ephemeralConnector = new EphemeralConnector()
       ephemeralConnector.configure(EPHEMERAL_ENDPOINT, EPHEMERAL_WEBSOCKET_ENDPOINT, w3cwebsocket)


### PR DESCRIPTION
This is needed to make the mobile app perform. (And just avoids unnecessary computation)